### PR TITLE
fix: use ubuntu keyserver with full key

### DIFF
--- a/enterprise/4.2/Dockerfile
+++ b/enterprise/4.2/Dockerfile
@@ -74,7 +74,7 @@ RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	echo "disable-ipv6" >> "${GNUPGHOME}/dirmngr.conf"; \
 	for key in $GPG_KEYS; do \
-		gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"; \
+		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done; \
 	gpg --batch --export $GPG_KEYS > /etc/apt/trusted.gpg.d/mongodb.gpg; \
 	command -v gpgconf && gpgconf --kill all || :; \

--- a/enterprise/4.4/Dockerfile
+++ b/enterprise/4.4/Dockerfile
@@ -74,7 +74,7 @@ RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	echo "disable-ipv6" >> "${GNUPGHOME}/dirmngr.conf"; \
 	for key in $GPG_KEYS; do \
-		gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"; \
+		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done; \
 	gpg --batch --export $GPG_KEYS > /etc/apt/trusted.gpg.d/mongodb.gpg; \
 	command -v gpgconf && gpgconf --kill all || :; \


### PR DESCRIPTION
The `keys.openpgp.org` only contained the relevant key _without_ the User ID present. The Ubuntu keyserver has the full key available (tested locally...).