### PR TITLE
chore: Some updates to docker&kerberos config

### DIFF
--- a/docker/enterprise/4.4/Dockerfile
+++ b/docker/enterprise/4.4/Dockerfile
@@ -90,7 +90,7 @@ ARG MONGO_REPO=repo.mongodb.org
 ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
 
 ENV MONGO_MAJOR 4.4
-ENV MONGO_VERSION 4.4.1
+ENV MONGO_VERSION 4.4.22
 # bashbrew-architectures:amd64 arm64v8 s390x
 RUN echo "deb http://$MONGO_REPO/apt/ubuntu bionic/${MONGO_PACKAGE%-unstable}/$MONGO_MAJOR multiverse" | tee "/etc/apt/sources.list.d/${MONGO_PACKAGE%-unstable}.list"
 

--- a/docker/kerberos/README.md
+++ b/docker/kerberos/README.md
@@ -13,6 +13,8 @@ Make sure you have this in `/etc/krb5.conf` (note the `domain_realm` section to 
 ```conf
 [libdefaults]
         dns_canonicalize_hostname = false
+        dns_lookup_kdc = false
+        dns_lookup_realm = false
 [realms]
         EXAMPLE.COM = {
                 kdc = localhost

--- a/docker/kerberos/README.md
+++ b/docker/kerberos/README.md
@@ -11,6 +11,8 @@ Make sure you have this line in your `/etc/hosts`:
 Make sure you have this in `/etc/krb5.conf` (note the `domain_realm` section to configure cross-realm):
 
 ```conf
+[libdefaults]
+        dns_canonicalize_hostname = false
 [realms]
         EXAMPLE.COM = {
                 kdc = localhost


### PR DESCRIPTION
* Our 4.4 mongodb image was mapped to 4.4.1. We've had quite a few patches since then. Not necessary, but we might as well bump that.
* The kerberos config we have to add locally mentioned in the README is out of date with what we write from compass when running the tests in CI.