### PR TITLE
fix: account for upstream server TLS option changes

### DIFF
--- a/docker/tls/mongod-server.conf
+++ b/docker/tls/mongod-server.conf
@@ -4,6 +4,7 @@ net:
   tls:
     mode: requireTLS
     certificateKeyFile: /etc/mongod/tls/server.pem
+    CAFile: /etc/mongod/tls/ca.pem
     allowInvalidCertificates: true
     allowInvalidHostnames: true
 


### PR DESCRIPTION
Same as https://github.com/mongodb-js/mongosh/pull/1838