### PR TITLE
fix: Add CAFile to mongod-server-named.conf

### DIFF
--- a/docker/tls/mongod-server-named.conf
+++ b/docker/tls/mongod-server-named.conf
@@ -4,6 +4,7 @@ net:
   tls:
     mode: requireTLS
     certificateKeyFile: /etc/mongod/tls/server-named.pem
+    CAFile: /etc/mongod/tls/ca.pem
     allowInvalidCertificates: true
     allowInvalidHostnames: true
 

--- a/docker/tls/mongod-server.conf
+++ b/docker/tls/mongod-server.conf
@@ -4,6 +4,7 @@ net:
   tls:
     mode: requireTLS
     certificateKeyFile: /etc/mongod/tls/server.pem
+    CAFile: /etc/mongod/tls/ca.pem
     allowInvalidCertificates: true
     allowInvalidHostnames: true
 


### PR DESCRIPTION
Missed this here: https://github.com/mongodb-js/devtools-docker-test-envs/pull/29