### PR TITLE
fix: allowConnectionsWithoutCertificates: true

### DIFF
--- a/docker/tls/mongod-server-client.conf
+++ b/docker/tls/mongod-server-client.conf
@@ -7,6 +7,7 @@ net:
     CAFile: /etc/mongod/tls/ca.pem
     allowInvalidCertificates: true
     allowInvalidHostnames: true
+    allowConnectionsWithoutCertificates: true
 
 storage:
   dbPath: "/data/db"

--- a/docker/tls/mongod-server-named.conf
+++ b/docker/tls/mongod-server-named.conf
@@ -7,6 +7,7 @@ net:
     CAFile: /etc/mongod/tls/ca.pem
     allowInvalidCertificates: true
     allowInvalidHostnames: true
+    allowConnectionsWithoutCertificates: true
 
 storage:
   dbPath: "/data/db"

--- a/docker/tls/mongod-server.conf
+++ b/docker/tls/mongod-server.conf
@@ -7,6 +7,7 @@ net:
     CAFile: /etc/mongod/tls/ca.pem
     allowInvalidCertificates: true
     allowInvalidHostnames: true
+    allowConnectionsWithoutCertificates: true
 
 storage:
   dbPath: "/data/db"


### PR DESCRIPTION
Based on https://jira.mongodb.org/browse/SERVER-72839?focusedCommentId=5678381&focusedId=5678381&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-5678381 and what mongosh' tests do it seems we need this because we're not specifying a certificate in the corresponding client connections/ tests.