### PR TITLE
fix(oidc-okta): update docker-compose build pathing to be relative

### DIFF
--- a/docker/oidc/identity-provider-okta/docker-compose.yaml
+++ b/docker/oidc/identity-provider-okta/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   mongodb-server-with-oidc-auth:
-    build: ./oidc/identity-provider-okta
+    build: .
     environment:
       OKTA_CLIENT_ID: ${OKTA_CLIENT_ID}
       OKTA_ISSUER: ${OKTA_ISSUER}


### PR DESCRIPTION
Fixes pathing issue
```bash
unable to prepare context: path "/Users/rhys/mongodb/devtools-docker-test-envs/docker/oidc/identity-provider-okta/oidc/identity-provider-okta" not found
```